### PR TITLE
Add Jenkins Pipeline for .NET Restore, Build & Test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,24 @@
+pipeline {
+    agent any
+
+    stages {
+
+        stage('Restore') {
+            steps {
+                sh 'dotnet restore'
+            }
+        }
+
+        stage('Build') {
+            steps {
+                sh 'dotnet build --no-restore'
+            }
+        }
+
+        stage('Test') {
+            steps {
+                sh 'dotnet test --no-build --verbosity normal'
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add Jenkinsfile that automates the CI process for our .NET project. It defines three key stages:

* **Restore:** Executes `dotnet restore` to fetch project dependencies.
* **Build:** Runs `dotnet build --no-restore` to compile the code.
* **Test:** Executes `dotnet test --no-build --verbosity normal` to run the tests.